### PR TITLE
Improve Messenger thread safety

### DIFF
--- a/Arrakasta.SimpleMVVM.Tests/MessengerConcurrencyTests.cs
+++ b/Arrakasta.SimpleMVVM.Tests/MessengerConcurrencyTests.cs
@@ -1,0 +1,40 @@
+using Arrakasta.SimpleMVVM.Messengers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Arrakasta.SimpleMVVM.Tests;
+
+public class MessengerConcurrencyTests
+{
+    [Fact]
+    public async Task Concurrent_Send_ShouldDeliverMessages()
+    {
+        var messenger = new Messenger();
+        int received = 0;
+        messenger.Subscribe<string>(_ => Interlocked.Increment(ref received));
+
+        var tasks = Enumerable.Range(0, 100).Select(_ => Task.Run(() => messenger.Send("msg")));
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(100, received);
+    }
+
+    [Fact]
+    public async Task Concurrent_Subscribe_Unsubscribe_Send_ShouldBeThreadSafe()
+    {
+        var messenger = new Messenger();
+        int received = 0;
+
+        var tasks = Enumerable.Range(0, 100).Select(_ => Task.Run(() =>
+        {
+            Action<string> handler = _ => Interlocked.Increment(ref received);
+            messenger.Subscribe(handler);
+            messenger.Send("test");
+            messenger.Unsubscribe(handler);
+        }));
+
+        await Task.WhenAll(tasks);
+
+        Assert.True(received >= 100);
+    }
+}

--- a/Arrakasta.SimpleMVVM/Messengers/Messenger.cs
+++ b/Arrakasta.SimpleMVVM/Messengers/Messenger.cs
@@ -3,31 +3,47 @@
 public class Messenger : IMessenger
 {
     private readonly Dictionary<Type, List<Delegate>> _handlers = new();
+    private readonly object _lock = new();
 
     public static IMessenger Default { get; } = new Messenger();
 
     public void Subscribe<T>(Action<T> action)
     {
-        if (!_handlers.TryGetValue(typeof(T), out var list))
+        lock (_lock)
         {
-            _handlers[typeof(T)] = list = [];
+            if (!_handlers.TryGetValue(typeof(T), out var list))
+            {
+                _handlers[typeof(T)] = list = [];
+            }
+            list.Add(action);
         }
-        list.Add(action);
     }
 
     public void Unsubscribe<T>(Action<T> action)
     {
-        if (_handlers.TryGetValue(typeof(T), out var list))
+        lock (_lock)
         {
-            list.Remove(action);
+            if (_handlers.TryGetValue(typeof(T), out var list))
+            {
+                list.Remove(action);
+                if (list.Count == 0)
+                {
+                    _handlers.Remove(typeof(T));
+                }
+            }
         }
     }
 
     public void Send<T>(T message)
     {
-        if (!_handlers.TryGetValue(typeof(T), out var list)) return;
+        List<Action<T>> handlers;
+        lock (_lock)
+        {
+            if (!_handlers.TryGetValue(typeof(T), out var list)) return;
+            handlers = list.OfType<Action<T>>().ToList();
+        }
 
-        foreach (var handler in list.OfType<Action<T>>())
+        foreach (var handler in handlers)
         {
             handler(message);
         }


### PR DESCRIPTION
## Summary
- ensure Messenger uses locking for internal handler list
- add concurrent unit tests

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876f418cac8333a3df39dc51ce4e08