### PR TITLE
Add ClearSubscriptions for Messenger

### DIFF
--- a/Arrakasta.SimpleMVVM.Tests/MessengerTest.cs
+++ b/Arrakasta.SimpleMVVM.Tests/MessengerTest.cs
@@ -26,6 +26,7 @@ public class MessengerTest
     [Fact]
     public void DefaultMessenger_ShouldBeSingleton()
     {
+        Messenger.Default.ClearSubscriptions();
         var messenger1 = Messenger.Default;
         var messenger2 = Messenger.Default;
         Assert.Same(messenger1, messenger2);
@@ -33,6 +34,7 @@ public class MessengerTest
     [Fact]
     public void DefaultMessenger_ShouldSendMessages()
     {
+        Messenger.Default.ClearSubscriptions();
         bool messageReceived = false;
         Messenger.Default.Subscribe<string>(message => messageReceived = true);
         Messenger.Default.Send("Test Message");

--- a/Arrakasta.SimpleMVVM.Tests/ViewModelBaseTest.cs
+++ b/Arrakasta.SimpleMVVM.Tests/ViewModelBaseTest.cs
@@ -45,6 +45,7 @@ public class ViewModelBaseTest
     [Fact]
     public void Set_ShouldNotifyMainViewModel_WhenMessageIsSent()
     {
+        Messenger.Default.ClearSubscriptions();
         string? receivedMessage = null;
         Messenger.Default.Subscribe<string>(message => receivedMessage = message);
         var mainViewModel = new TestViewModel

--- a/Arrakasta.SimpleMVVM/Messengers/IMessenger.cs
+++ b/Arrakasta.SimpleMVVM/Messengers/IMessenger.cs
@@ -5,4 +5,8 @@ public interface IMessenger
     void Subscribe<T>(Action<T> action);
     void Unsubscribe<T>(Action<T> action);
     void Send<T>(T message);
+    /// <summary>
+    /// Removes all registered message handlers.
+    /// </summary>
+    void ClearSubscriptions();
 }

--- a/Arrakasta.SimpleMVVM/Messengers/Messenger.cs
+++ b/Arrakasta.SimpleMVVM/Messengers/Messenger.cs
@@ -32,4 +32,9 @@ public class Messenger : IMessenger
             handler(message);
         }
     }
+
+    public void ClearSubscriptions()
+    {
+        _handlers.Clear();
+    }
 }


### PR DESCRIPTION
## Summary
- enable clearing message handlers via new `ClearSubscriptions` method
- update tests to clear default messenger before each use

## Testing
- `dotnet test --no-build` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68876f4c1ca88333b9338b11625a8b9a