### PR TITLE
Fix encoding for C# sources

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/Arrakasta.SimpleMVVM.Tests/CommandManagerTests.cs
+++ b/Arrakasta.SimpleMVVM.Tests/CommandManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using Arrakasta.SimpleMVVM.Commands;
+using Arrakasta.SimpleMVVM.Commands;
 
 namespace Arrakasta.SimpleMVVM.Tests;
 

--- a/Arrakasta.SimpleMVVM.Tests/MessengerTest.cs
+++ b/Arrakasta.SimpleMVVM.Tests/MessengerTest.cs
@@ -1,4 +1,4 @@
-﻿using Arrakasta.SimpleMVVM.Messengers;
+using Arrakasta.SimpleMVVM.Messengers;
 
 namespace Arrakasta.SimpleMVVM.Tests;
 

--- a/Arrakasta.SimpleMVVM.Tests/ObservableObjectTest.cs
+++ b/Arrakasta.SimpleMVVM.Tests/ObservableObjectTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Arrakasta.SimpleMVVM.Tests;
+namespace Arrakasta.SimpleMVVM.Tests;
 
 public class ObservableObjectTest
 {

--- a/Arrakasta.SimpleMVVM.Tests/RelayCommandTest.cs
+++ b/Arrakasta.SimpleMVVM.Tests/RelayCommandTest.cs
@@ -1,4 +1,4 @@
-﻿using Arrakasta.SimpleMVVM.Commands;
+using Arrakasta.SimpleMVVM.Commands;
 
 namespace Arrakasta.SimpleMVVM.Tests;
 

--- a/Arrakasta.SimpleMVVM.Tests/ViewModelBaseTest.cs
+++ b/Arrakasta.SimpleMVVM.Tests/ViewModelBaseTest.cs
@@ -1,4 +1,4 @@
-﻿using Arrakasta.SimpleMVVM.Commands;
+using Arrakasta.SimpleMVVM.Commands;
 using Arrakasta.SimpleMVVM.Messengers;
 using System.Windows.Input;
 

--- a/Arrakasta.SimpleMVVM/Commands/CommandManager.cs
+++ b/Arrakasta.SimpleMVVM/Commands/CommandManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Input;
+using System.Windows.Input;
 
 namespace Arrakasta.SimpleMVVM.Commands;
 

--- a/Arrakasta.SimpleMVVM/Commands/IRaiseCanExecuteChanged.cs
+++ b/Arrakasta.SimpleMVVM/Commands/IRaiseCanExecuteChanged.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Input;
+using System.Windows.Input;
 
 namespace Arrakasta.SimpleMVVM.Commands;
 

--- a/Arrakasta.SimpleMVVM/Commands/RelayCommand.cs
+++ b/Arrakasta.SimpleMVVM/Commands/RelayCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace Arrakasta.SimpleMVVM.Commands;
+namespace Arrakasta.SimpleMVVM.Commands;
 
 public class RelayCommand : IRaiseCanExecuteChanged
 {

--- a/Arrakasta.SimpleMVVM/Commands/RelayCommand{T}.cs
+++ b/Arrakasta.SimpleMVVM/Commands/RelayCommand{T}.cs
@@ -1,4 +1,4 @@
-﻿namespace Arrakasta.SimpleMVVM.Commands;
+namespace Arrakasta.SimpleMVVM.Commands;
 
 public class RelayCommand<T> : IRaiseCanExecuteChanged
 {

--- a/Arrakasta.SimpleMVVM/Messengers/IMessenger.cs
+++ b/Arrakasta.SimpleMVVM/Messengers/IMessenger.cs
@@ -1,4 +1,4 @@
-﻿namespace Arrakasta.SimpleMVVM.Messengers;
+namespace Arrakasta.SimpleMVVM.Messengers;
 
 public interface IMessenger
 {

--- a/Arrakasta.SimpleMVVM/Messengers/Messenger.cs
+++ b/Arrakasta.SimpleMVVM/Messengers/Messenger.cs
@@ -1,4 +1,4 @@
-﻿namespace Arrakasta.SimpleMVVM.Messengers;
+namespace Arrakasta.SimpleMVVM.Messengers;
 
 public class Messenger : IMessenger
 {

--- a/Arrakasta.SimpleMVVM/ViewModels/ObservableObject.cs
+++ b/Arrakasta.SimpleMVVM/ViewModels/ObservableObject.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace Arrakasta.SimpleMVVM;

--- a/Arrakasta.SimpleMVVM/ViewModels/ViewModelBase.cs
+++ b/Arrakasta.SimpleMVVM/ViewModels/ViewModelBase.cs
@@ -1,4 +1,4 @@
-﻿using Arrakasta.SimpleMVVM.Commands;
+using Arrakasta.SimpleMVVM.Commands;
 using Arrakasta.SimpleMVVM.Messengers;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM from all `.cs` files
- ensure every source ends with a newline
- add `.editorconfig` with UTF-8 encoding and newline rules

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68877187342c83338ae3ebcbbb11b228