### PR TITLE
Improve RelayCommand<T> parameter handling

### DIFF
--- a/Arrakasta.SimpleMVVM.Tests/RelayCommandTest.cs
+++ b/Arrakasta.SimpleMVVM.Tests/RelayCommandTest.cs
@@ -64,4 +64,22 @@ public class RelayCommandTest
         command.RaiseCanExecuteChanged();
         Assert.True(canExecuteChangedRaised);
     }
+
+    [Fact]
+    public void RelayCommand_WithNullParameter_ShouldUseDefault()
+    {
+        int result = -1;
+        var command = new RelayCommand<int>(param => result = param);
+        command.Execute(null);
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void RelayCommand_WithWrongParameterType_ShouldThrow()
+    {
+        var command = new RelayCommand<string>(_ => { });
+        Assert.Throws<ArgumentException>(() => command.Execute(42));
+        Assert.Throws<ArgumentException>(() => command.CanExecute(42));
+    }
 }
+

--- a/Arrakasta.SimpleMVVM/Commands/RelayCommand{T}.cs
+++ b/Arrakasta.SimpleMVVM/Commands/RelayCommand{T}.cs
@@ -20,10 +20,26 @@ public class RelayCommand<T> : IRaiseCanExecuteChanged
         {
             return;
         }
-        _execute((T)parameter!);
+
+        _execute(CastParameter(parameter));
     }
 
-    public bool CanExecute(object? parameter) => _canExecute?.Invoke((T)parameter!) ?? true;
+    public bool CanExecute(object? parameter) => _canExecute?.Invoke(CastParameter(parameter)) ?? true;
+
+    private static T CastParameter(object? parameter)
+    {
+        if (parameter is null)
+        {
+            return default!;
+        }
+
+        if (parameter is not T value)
+        {
+            throw new ArgumentException($"Expected parameter of type {typeof(T)}, got {parameter.GetType()}");
+        }
+
+        return value;
+    }
 
     public void RaiseCanExecuteChanged()
     {


### PR DESCRIPTION
## Summary
- validate RelayCommand<T> parameters
- test null parameter and invalid parameter type cases

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68876e05e6688333825561cacf38613c