### PR TITLE
Add async relay command support

### DIFF
--- a/Arrakasta.SimpleMVVM.Tests/AsyncRelayCommandTest.cs
+++ b/Arrakasta.SimpleMVVM.Tests/AsyncRelayCommandTest.cs
@@ -1,0 +1,85 @@
+using Arrakasta.SimpleMVVM.Commands;
+
+namespace Arrakasta.SimpleMVVM.Tests;
+
+public class AsyncRelayCommandTest
+{
+    [Fact]
+    public async Task AsyncRelayCommand_ShouldExecuteAsyncAction()
+    {
+        var tcs = new TaskCompletionSource();
+        var command = new AsyncRelayCommand(() =>
+        {
+            tcs.SetResult();
+            return Task.CompletedTask;
+        });
+
+        command.Execute(null);
+        await tcs.Task;
+    }
+
+    [Fact]
+    public async Task AsyncRelayCommand_ShouldNotExecuteWhenCanExecuteFalse()
+    {
+        var tcs = new TaskCompletionSource();
+        var command = new AsyncRelayCommand(() =>
+        {
+            tcs.SetResult();
+            return Task.CompletedTask;
+        }, () => false);
+
+        command.Execute(null);
+
+        await Task.Delay(100);
+        Assert.False(tcs.Task.IsCompleted);
+    }
+
+    [Fact]
+    public void AsyncRelayCommand_ShouldRaiseCanExecuteChanged()
+    {
+        var command = new AsyncRelayCommand(() => Task.CompletedTask);
+        bool raised = false;
+        command.CanExecuteChanged += (_, _) => raised = true;
+        command.RaiseCanExecuteChanged();
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public async Task AsyncRelayCommand_Generic_ShouldExecuteAsyncAction()
+    {
+        var tcs = new TaskCompletionSource();
+        var command = new AsyncRelayCommand<int>(i =>
+        {
+            tcs.SetResult();
+            return Task.CompletedTask;
+        });
+
+        command.Execute(5);
+        await tcs.Task;
+    }
+
+    [Fact]
+    public async Task AsyncRelayCommand_Generic_ShouldNotExecuteWhenCanExecuteFalse()
+    {
+        var tcs = new TaskCompletionSource();
+        var command = new AsyncRelayCommand<int>(i =>
+        {
+            tcs.SetResult();
+            return Task.CompletedTask;
+        }, i => false);
+
+        command.Execute(5);
+        await Task.Delay(100);
+        Assert.False(tcs.Task.IsCompleted);
+    }
+
+    [Fact]
+    public void AsyncRelayCommand_Generic_ShouldRaiseCanExecuteChanged()
+    {
+        var command = new AsyncRelayCommand<int>(_ => Task.CompletedTask);
+        bool raised = false;
+        command.CanExecuteChanged += (_, _) => raised = true;
+        command.RaiseCanExecuteChanged();
+        Assert.True(raised);
+    }
+}

--- a/Arrakasta.SimpleMVVM/Commands/AsyncRelayCommand.cs
+++ b/Arrakasta.SimpleMVVM/Commands/AsyncRelayCommand.cs
@@ -1,0 +1,39 @@
+using System.Windows.Input;
+
+namespace Arrakasta.SimpleMVVM.Commands;
+
+public class AsyncRelayCommand : IRaiseCanExecuteChanged
+{
+    private readonly Func<Task> _execute;
+    private readonly Func<bool>? _canExecute;
+    private bool _isExecuting;
+
+    public event EventHandler? CanExecuteChanged;
+
+    public AsyncRelayCommand(Func<Task> execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+        CommandManager.Register(this);
+    }
+
+    public bool CanExecute(object? parameter) => !_isExecuting && (_canExecute?.Invoke() ?? true);
+
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter)) return;
+        try
+        {
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+            await _execute();
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/Arrakasta.SimpleMVVM/Commands/AsyncRelayCommand{T}.cs
+++ b/Arrakasta.SimpleMVVM/Commands/AsyncRelayCommand{T}.cs
@@ -1,0 +1,59 @@
+using System.Windows.Input;
+
+namespace Arrakasta.SimpleMVVM.Commands;
+
+public class AsyncRelayCommand<T> : IRaiseCanExecuteChanged
+{
+    private readonly Func<T, Task> _execute;
+    private readonly Func<T, bool>? _canExecute;
+    private bool _isExecuting;
+
+    public event EventHandler? CanExecuteChanged;
+
+    public AsyncRelayCommand(Func<T, Task> execute, Func<T, bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+        CommandManager.Register(this);
+    }
+
+    public bool CanExecute(object? parameter)
+    {
+        var param = CastParameter(parameter);
+        return !_isExecuting && (_canExecute?.Invoke(param) ?? true);
+    }
+
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter)) return;
+        var param = CastParameter(parameter);
+        try
+        {
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+            await _execute(param);
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    private static T CastParameter(object? parameter)
+    {
+        if (parameter is null)
+        {
+            return default!;
+        }
+
+        if (parameter is not T value)
+        {
+            throw new ArgumentException($"Expected parameter of type {typeof(T)}, got {parameter.GetType()}");
+        }
+
+        return value;
+    }
+
+    public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Arrakasta.SimpleMVVM is a lightweight and easy-to-use MVVM (Model-View-ViewModel
 - `ObservableObject`: Base class for property change notifications (INotifyPropertyChanged).
 - `ViewModelBase`: Simplifies ViewModel creation and property management.
 - `RelayCommand` and `RelayCommand<T>`: Flexible command implementations for UI actions.
+- `AsyncRelayCommand` and `AsyncRelayCommand<T>`: Awaitable command variants for long-running operations.
 - `Messenger` and `IMessenger`: Decoupled communication between ViewModels and components.
 - `CommandManager`: Centralized command state management.
 - Minimal dependencies and cross-platform support.


### PR DESCRIPTION
## Summary
- implement AsyncRelayCommand and AsyncRelayCommand<T>
- document new async commands in the README
- add unit tests for async commands

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6887827361648333b481084633b995de