### PR TITLE
Add GitHub Actions build and NuGet packaging

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,32 @@
+name: .NET
+
+on:
+  push:
+    branches: [ master, main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+      - name: Test
+        run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage"
+      - name: Pack
+        run: dotnet pack --no-build --configuration Release --output ./artifacts
+      - name: Publish to NuGet
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ./artifacts/*.nupkg --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json

--- a/Arrakasta.SimpleMVVM/Arrakasta.SimpleMVVM.csproj
+++ b/Arrakasta.SimpleMVVM/Arrakasta.SimpleMVVM.csproj
@@ -4,6 +4,17 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Package metadata for NuGet -->
+    <PackageId>Arrakasta.SimpleMVVM</PackageId>
+    <Version>1.0.0</Version>
+    <Authors>Arrakasta</Authors>
+    <Company>Arrakasta</Company>
+    <Product>Arrakasta.SimpleMVVM</Product>
+    <Description>Lightweight MVVM toolkit for .NET 8 applications.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/Arrakasta/Arrakasta.SimpleMVVM</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/Arrakasta/Arrakasta.SimpleMVVM</PackageProjectUrl>
   </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ public class MainViewModel : ViewModelBase
 
 Unit tests are available in the `Arrakasta.SimpleMVVM.Tests` project.
 
+## Continuous Integration
+
+The project uses a GitHub Actions workflow to build, test and publish the
+package to NuGet. Packages are pushed when a tag starting with `v` is created
+and the `NUGET_API_KEY` secret is configured in the repository settings.
+
 ## License
 
 This project is licensed under the MIT License.


### PR DESCRIPTION
## Summary
- enable packing metadata in `Arrakasta.SimpleMVVM.csproj`
- add GitHub Actions workflow to build, test and publish to NuGet
- document CI pipeline in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879809bbe483339f20fe1b4817e959