### PR TITLE
Add version extraction from Git tags for packaging

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,6 +23,9 @@ jobs:
         run: dotnet build --no-restore --configuration Release
       - name: Test
         run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage"
+      - name: Extract version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/v} >> $GITHUB_ENV
       - name: Pack
         run: dotnet pack --no-build --configuration Release --output ./artifacts
       - name: Publish to NuGet

--- a/Arrakasta.SimpleMVVM/Arrakasta.SimpleMVVM.csproj
+++ b/Arrakasta.SimpleMVVM/Arrakasta.SimpleMVVM.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <!-- Package metadata for NuGet -->
     <PackageId>Arrakasta.SimpleMVVM</PackageId>
-    <Version>1.0.0</Version>
+    <Version>$(PackageVersion)</Version>
     <Authors>Arrakasta</Authors>
     <Company>Arrakasta</Company>
     <Product>Arrakasta.SimpleMVVM</Product>


### PR DESCRIPTION
Updated `dotnet.yml` to extract version from Git tags and set `PACKAGE_VERSION` environment variable. Changed version in `Arrakasta.SimpleMVVM.csproj` from a hardcoded value to a variable (`$(PackageVersion)`) for dynamic versioning during the build process.