### PR TITLE
Fix syntax error in PACKAGE_VERSION assignment

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,7 +25,7 @@ jobs:
         run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage"
       - name: Extract version from tag
         if: startsWith(github.ref, 'refs/tags/')
-        run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/v} >> $GITHUB_ENV
+        run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
       - name: Pack
         run: dotnet pack --no-build --configuration Release --output ./artifacts
       - name: Publish to NuGet


### PR DESCRIPTION
Corrected the syntax for setting the PACKAGE_VERSION environment variable in the GitHub Actions workflow. The original line was missing a closing quotation mark, which could lead to a syntax error. The updated line ensures proper assignment of the version from the Git tag.