### PR TITLE
Refactor version extraction in dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,7 +25,9 @@ jobs:
         run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage"
       - name: Extract version from tag
         if: startsWith(github.ref, 'refs/tags/')
-        run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "PACKAGE_VERSION=$VERSION" >> $GITHUB_ENV
       - name: Pack
         if: startsWith(github.ref, 'refs/tags/')
         run: dotnet pack --no-build --configuration Release --output ./artifacts -p:PackageVersion=${{ env.PACKAGE_VERSION }}


### PR DESCRIPTION
Updated the package version extraction from GitHub tags to use a multi-line command. This change enhances readability and maintainability by assigning the version to a variable before echoing it into the environment variable.